### PR TITLE
Force (re)encoding of UTF-8 in `Burlap.parser`

### DIFF
--- a/lib/burlap.rb
+++ b/lib/burlap.rb
@@ -10,7 +10,7 @@ module Burlap
   def self.parse io_handle
     listener = Listener.new
     parser = Nokogiri::XML::SAX::Parser.new(listener)
-    parser.parse(io_handle)
+    parser.parse(io_handle.encode!(Encoding::UTF_8))
     listener.result
   end
 

--- a/spec/burlap_spec.rb
+++ b/spec/burlap_spec.rb
@@ -13,10 +13,27 @@ describe Burlap do
 
   describe ".parse" do
     it "should be specced"
+
+    context "when emoji in response" do
+      context "with UTF-8 encoded burlap" do
+        let(:body) { "<burlap:reply><map><type></type><string>emoji</string><string>\u{1F33B}</string></map></burlap:reply>".force_encoding(Encoding::UTF_8) }
+
+        it do
+          expect(Burlap.parse(body)).to eq(Burlap::Hash["emoji" => "\u{1F33B}"])
+        end
+      end
+
+      context "with ISO-8859-1 encoded burlap" do
+        let(:body) { "<burlap:reply><map><type></type><string>emoji</string><string>\xED\xA0\xBC</string></map></burlap:reply>".force_encoding(Encoding::ISO_8859_1) }
+
+        it do
+          expect(Burlap.parse(body)).to eq(Burlap::Hash["emoji" => "í ¼"])
+        end
+      end
+    end
   end
 
   describe ".dump" do
     it "should be specced"
   end
-
 end


### PR DESCRIPTION
A Burlap API is incorrectly escaping emoji as a series of hex bytes that
are illegal UTF-8 byte sequences.

The HTTP response is not reporting its character set so is interpreted
as UTF-8 but the illegal sequence causes Nokogiri to immediate abort
returning `nil` which goes on to cause worse problems.

Using `encode` on the parser input does not change UTF-8 strings but
will safely replace the hex digits with valid data. This allows the
parsing to continue.

There is an optional second parameter to pass the encoding to use if it
is available, otherwise UTF-8 will be used.