### PR TITLE
Fix `Jenkinsfile` bundling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ log/*
 doc/*
 .yardoc
 Gemfile.lock
+vendor

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,54 +4,6 @@ pipeline {
   stages {
     stage("Run tests") {
       parallel {
-        stage("Ruby 1.9.3") {
-          agent {
-            docker {
-              image 'ruby:1.9.3'
-            }
-          }
-          steps {
-            sh 'BUNDLE_APP_CONFIG=/tmp/bundle.config BUNDLE_DISABLE_SHARED_GEMS=true bundle install'
-            sh 'BUNDLE_APP_CONFIG=/tmp/bundle.config bundle exec rake spec'
-            sh 'BUNDLE_APP_CONFIG=/tmp/bundle.config bundle exec rake doc'
-          }
-        }
-        stage("Ruby 2.0") {
-          agent {
-            docker {
-              image 'ruby:2.0'
-            }
-          }
-          steps {
-            sh 'bundle install'
-            sh 'bundle exec rake spec'
-            sh 'bundle exec rake doc'
-          }
-        }
-        stage("Ruby 2.1") {
-          agent {
-            docker {
-              image 'ruby:2.1'
-            }
-          }
-          steps {
-            sh 'bundle install'
-            sh 'bundle exec rake spec'
-            sh 'bundle exec rake doc'
-          }
-        }
-        stage("Ruby 2.2") {
-          agent {
-            docker {
-              image 'ruby:2.2'
-            }
-          }
-          steps {
-            sh 'bundle install'
-            sh 'bundle exec rake spec'
-            sh 'bundle exec rake doc'
-          }
-        }
         stage("Ruby 2.3") {
           agent {
             docker {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
             }
           }
           steps {
-            sh 'BUNDLE_APP_CONFIG=/tmp/bundle.config BUNDLE_DISABLE_SHARED_GEMS=true bundle install --deployment'
+            sh 'BUNDLE_APP_CONFIG=/tmp/bundle.config BUNDLE_DISABLE_SHARED_GEMS=true bundle install'
             sh 'BUNDLE_APP_CONFIG=/tmp/bundle.config bundle exec rake spec'
             sh 'BUNDLE_APP_CONFIG=/tmp/bundle.config bundle exec rake doc'
           }
@@ -23,7 +23,7 @@ pipeline {
             }
           }
           steps {
-            sh 'bundle install --deployment'
+            sh 'bundle install'
             sh 'bundle exec rake spec'
             sh 'bundle exec rake doc'
           }
@@ -35,7 +35,7 @@ pipeline {
             }
           }
           steps {
-            sh 'bundle install --deployment'
+            sh 'bundle install'
             sh 'bundle exec rake spec'
             sh 'bundle exec rake doc'
           }
@@ -47,7 +47,7 @@ pipeline {
             }
           }
           steps {
-            sh 'bundle install --deployment'
+            sh 'bundle install'
             sh 'bundle exec rake spec'
             sh 'bundle exec rake doc'
           }
@@ -59,7 +59,7 @@ pipeline {
             }
           }
           steps {
-            sh 'bundle install --deployment'
+            sh 'bundle install'
             sh 'bundle exec rake spec'
             sh 'bundle exec rake doc'
           }
@@ -71,7 +71,7 @@ pipeline {
             }
           }
           steps {
-            sh 'bundle install --deployment'
+            sh 'bundle install'
             sh 'bundle exec rake spec'
             sh 'bundle exec rake doc'
           }
@@ -83,7 +83,7 @@ pipeline {
             }
           }
           steps {
-            sh 'bundle install --deployment'
+            sh 'bundle install'
             sh 'bundle exec rake spec'
             sh 'bundle exec rake doc'
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,66 @@ pipeline {
             sh 'bundle exec rake doc'
           }
         }
-
+        stage("Ruby 2.6") {
+          agent {
+            docker {
+              image 'ruby:2.6'
+            }
+          }
+          steps {
+            sh 'bundle install'
+            sh 'bundle exec rake spec'
+            sh 'bundle exec rake doc'
+          }
+        }
+        stage("Ruby 2.7") {
+          agent {
+            docker {
+              image 'ruby:2.7'
+            }
+          }
+          steps {
+            sh 'bundle install'
+            sh 'bundle exec rake spec'
+            sh 'bundle exec rake doc'
+          }
+        }
+        stage("Ruby 3.0") {
+          agent {
+            docker {
+              image 'ruby:3.0'
+            }
+          }
+          steps {
+            sh 'bundle install'
+            sh 'bundle exec rake spec'
+            sh 'bundle exec rake doc'
+          }
+        }
+        stage("Ruby 3.1") {
+          agent {
+            docker {
+              image 'ruby:3.1'
+            }
+          }
+          steps {
+            sh 'bundle install'
+            sh 'bundle exec rake spec'
+            sh 'bundle exec rake doc'
+          }
+        }
+        stage("Ruby 3.2") {
+          agent {
+            docker {
+              image 'ruby:3.2'
+            }
+          }
+          steps {
+            sh 'bundle install'
+            sh 'bundle exec rake spec'
+            sh 'bundle exec rake doc'
+          }
+        }
       }
     }
   }

--- a/burlap.gemspec
+++ b/burlap.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = ">= 2.3.0"
+
   s.add_dependency "nokogiri", ">= 1.4.4"
   s.add_dependency "builder", ">= 2.0"
 


### PR DESCRIPTION
This tweaks the `Jenkinsfile` to run tests on newer versions of Ruby and
also drops support for some older versions in testing.

The gemspec is updated accordingly to demarcate supported and tested
versions.
