### PR TITLE
Replace Proc "hack" to work with Ruby 3.0+

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["2.3", "2.4", "2.5", "2.6", "2.7"]
+        ruby-version: ["2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1"]
 
     steps:
     - uses: actions/checkout@v3

--- a/lib/burlap/default_resolver.rb
+++ b/lib/burlap/default_resolver.rb
@@ -3,21 +3,15 @@ require "ostruct"
 
 module Burlap
   class DefaultResolver
-
-    def mappings *names
+    def mappings(*names, &block)
       # Default's to a hash
       @mappings ||= {}
       # return early, return often. Or is that release?
       return @mappings if names.empty?
 
-      raise ArgumentError, "block is required when name is given" unless block_given?
-
-      # hack to get the passed block in a variable with less speed cost than &block in args
-      block = Proc.new
-
       # Set said block for each name
       names.each do |name|
-        @mappings[name] = block
+        @mappings[name] = proc(&block)
       end
 
       @mappings
@@ -29,7 +23,6 @@ module Burlap
       mapping = mappings[obj.name] || raise(Error, "couldn't handle tag #{obj.name.inspect}")
       mapping.call(obj)
     end
-
   end
 
   # And set ourselves as the default

--- a/spec/burlap/default_resolver_spec.rb
+++ b/spec/burlap/default_resolver_spec.rb
@@ -4,14 +4,11 @@ describe Burlap::DefaultResolver do
 
   describe "#mappings" do
     before { @resolver = Burlap::DefaultResolver.new }
+
     it "should default to a hash" do
       @resolver.mappings.should == {}
     end
-    it "should raise an error if name is passed with no block" do
-      lambda do
-        @resolver.mappings "thing"
-      end.should raise_error(ArgumentError, "block is required when name is given")
-    end
+
     it "should store a single mapping when passed a name and block" do
       @resolver.mappings["thing"].should == nil
 
@@ -24,6 +21,7 @@ describe Burlap::DefaultResolver do
       @result.should be_a_kind_of(Proc)
       @result.call.should == "thing's block"
     end
+
     it "should store the same block against multiple mappings when passed more than one name at once" do
       @resolver.mappings "black", "white" do
         # Mixing black and white keys. Geddit?
@@ -38,6 +36,7 @@ describe Burlap::DefaultResolver do
         result.call.should == "half-caste symphony"
       end
     end
+
     it "should use the last argument if it responds to #call in place of a block"
   end
 
@@ -65,6 +64,7 @@ describe Burlap::DefaultResolver do
         true_tag = Burlap::BaseTag.new(:name => "boolean", :value => "1")
         @resolver.convert_to_native(true_tag).should == true
       end
+
       it "should parse false" do
         false_tag = Burlap::BaseTag.new(:name => "boolean", :value => "0")
         @resolver.convert_to_native(false_tag).should == false
@@ -77,11 +77,13 @@ describe Burlap::DefaultResolver do
 
         arr.should == []
       end
+
       it "should parse an array containing one string" do
         arr = Burlap.parse "<list><type>[string</type><length>1</length><string>1</string></list>"
 
         arr.should == ["1"]
       end
+
       it "should parse an array with multiple elements" do
         arr = Burlap.parse %{<list><type></type><length>3</length><int>0</int><double>1.3</double><string>foobar</string></list>}
 
@@ -97,7 +99,5 @@ describe Burlap::DefaultResolver do
         response.should == str
       end
     end
-
   end
-
 end


### PR DESCRIPTION
The `DefaultResolver` relied on a self-declared "hack" which was later
deprecated and removed in Ruby 3.0. It relied on a check for a given
block and then assignment of a `Proc`.

The fix involves explicitly including the `&block` argument and removing
the check for it, since the check fails on earlier ruby versions but the
code itself works.

The spec that checked for the `ArgumentError` raised in this case was
thus broken and so removed.