### PR TITLE
Unpin `rake` version

### DIFF
--- a/burlap.gemspec
+++ b/burlap.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "activesupport", ">= 2.3.4"
   s.add_development_dependency "timecop", "= 0.3.5"
-  s.add_development_dependency "rake", "<11"
+  s.add_development_dependency "rake"
   s.add_development_dependency "yard"
   s.add_development_dependency "bluecloth", ">= 2.2"
 end


### PR DESCRIPTION
This was previously set to a low version to prevent issues with Ruby 1.9 which is no longer supported, so the version can be unpinned.