### PR TITLE
Declare supported Ruby versions as >= 2.3

### DIFF
--- a/burlap.gemspec
+++ b/burlap.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = "> 2.3"
+
   s.add_dependency "nokogiri", ">= 1.4.4"
   s.add_dependency "builder", ">= 2.0"
 


### PR DESCRIPTION
This confirms that we are only planning to support Ruby 2.3 at the oldest with `burlap` so the gemspec has been updated to declare that.