### PR TITLE
Remove `bluecloth` gem

### DIFF
--- a/burlap.gemspec
+++ b/burlap.gemspec
@@ -29,5 +29,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency "timecop", "= 0.3.5"
   s.add_development_dependency "rake"
   s.add_development_dependency "yard"
-  s.add_development_dependency "bluecloth", ">= 2.2"
 end


### PR DESCRIPTION
We don't appear to use it in the actual library or for generating yardoc so not sure why it was declared as a dependency.